### PR TITLE
Add four new scrapers

### DIFF
--- a/metascraper.py
+++ b/metascraper.py
@@ -19,6 +19,10 @@ from scrapers.githubgptssearchscraper import GitHubGPTsSearchScraper
 from scrapers.meetgptsscraper import MeetGPTsScraper
 from scrapers.meetupsaiscraper import MeetupsAIScraper
 from scrapers.gptshuntscraper import GPTsHuntScraper
+from scrapers.customgptslistscraper import CustomGPTsListScraper
+from scrapers.gptdirectoryscraper import GPTDirectoryScraper
+from scrapers.customgptsscraper import CustomGPTsScraper
+from scrapers.gptcollectionscraper import GPTCollectionScraper
 import json
 
 parser = argparse.ArgumentParser(
@@ -102,6 +106,14 @@ def decode_scrapers(name):
             return MeetupsAIScraper()
         case "gptshunt.tech":
             return GPTsHuntScraper()
+        case "customgptslist.com":
+            return CustomGPTsListScraper()
+        case "gptdirectory.co":
+            return GPTDirectoryScraper()
+        case "customgpts.info":
+            return CustomGPTsScraper()
+        case "gpt-collection.com":
+            return GPTCollectionScraper()
         case _:
             raise ValueError(f"Unknown scraper name/Not implemented: {name}")
 
@@ -120,7 +132,7 @@ def main():
 
     if not args.use_json:
         title = 'Select scrapers to run: '
-        options = ['plugin.surf', "GitHub - GPTsSearch CSV Scrape", 'topgpts.ai', 'topgpts.ai-tiny', "allgpts.co", "botsbarn.com", "assistanthunt.com", 'Twitter', 'meetgpts.com', 'meetups.ai', 'gptshunt.tech']
+        options = ['plugin.surf', "GitHub - GPTsSearch CSV Scrape", 'topgpts.ai', 'topgpts.ai-tiny', "allgpts.co", "botsbarn.com", "assistanthunt.com", 'Twitter', 'meetgpts.com', 'meetups.ai', 'gptshunt.tech', 'customgptslist.com', 'gptdirectory.co', 'customgpts.info', 'gpt-collection.com']
         selected = pick(options, title, multiselect=True, min_selection_count=1)
         for i in range(len(selected)):
             selected[i] = selected[i][0]

--- a/scrapers/customgptslistscraper.py
+++ b/scrapers/customgptslistscraper.py
@@ -1,0 +1,103 @@
+import sys
+import time
+
+import selenium
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+# Import chromedriver
+from selenium.webdriver.chrome.options import Options
+import pickle
+
+import traceback
+import os
+import time
+import json
+import shutil
+import argparse
+import requests
+import config
+import scraperutils
+from scraperutils import bcolors
+
+
+class CustomGPTsListScraper:
+    ### Class Variables
+    args = None
+    driver = None
+    ID = "customgptslistscraper"
+
+    BACKUP_HREF_FILE_NAME = "../top_gpts_href_values_bak.json"
+    BACKUP_OPENAI_URLS_FILE_NAME = "../top_gpts_openai_urls_bak.json"
+
+    def scrape_all_gpts(self):
+        self.driver.get('https://customgptslist.com/gpts')
+        # Feedback loop to scroll to the bottom
+        try:
+            while True:
+                scraperutils.scroll_to_bottom(self.driver)
+                time.sleep(2)
+                if scraperutils.is_at_bottom(self.driver):
+                    # If at the bottom, you can break out of the loop or perform additional actions
+                    break
+        except KeyboardInterrupt:
+            # Handle interruption (e.g., user pressing Ctrl+C)
+            pass
+
+        print("Completed Scrolling to Bottom")
+        elements = self.driver.find_elements(By.TAG_NAME, "a")
+
+        # Create an empty list to store href values
+        href_values = []
+
+        # Iterate through the WebElement array and get href attributes
+        for element in elements:
+            href = element.get_attribute("href")
+            href_values.append(href)
+
+        # Verify the list of href values, remove any None values
+        href_values = [x for x in href_values if x is not None]
+
+        with open(self.BACKUP_HREF_FILE_NAME, "w") as outfile:
+            json.dump(href_values, outfile)
+
+        return href_values
+
+
+    def scrape(self, email_reporting=False) -> list:
+        '''
+        All scrapers must implement this method.
+        It should return a list of OpenAI URLs corresponding to GPTs scraped
+        from the class's web source. scrape() should also accept 3 mandatory kwargs
+        but may also accept additional keyword arguments
+
+        :param email_reporting: Whether it should send an email if there is a failure
+        :return: List of strings that should be valid URLs
+        '''
+        self.driver = scraperutils.start_webdriver()
+        subpage_urls = self.scrape_all_gpts()
+        self.driver.quit()
+
+        openai_urls = []
+        for x in subpage_urls:
+            openai_urls.append(scraperutils.extract_openai_url(x))
+
+        num_failures = openai_urls.count(None)
+        # Count the # of None values in openai_urls
+        print(f"{bcolors.OKCYAN} Failures: {num_failures} {bcolors.ENDC}")
+
+        openai_urls = [x for x in openai_urls if x is not None]
+
+        print("Verifying uniqueness...")
+        dupes = scraperutils.compute_duplicates(openai_urls)
+        if len(dupes) > 0:
+            print(f"{bcolors.WARNING}{len(dupes)} duplicates found{bcolors.ENDC}")
+            print(dupes)
+
+        # Remove duplicates from list
+        openai_urls = list(set(openai_urls))
+
+        with open(self.BACKUP_OPENAI_URLS_FILE_NAME, "w") as outfile:
+            json.dump(openai_urls, outfile)
+
+        return openai_urls
+

--- a/scrapers/customgptsscraper.py
+++ b/scrapers/customgptsscraper.py
@@ -1,0 +1,116 @@
+import sys
+import time
+
+import selenium
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+# Import chromedriver
+from selenium.webdriver.chrome.options import Options
+import pickle
+
+import traceback
+import os
+import time
+import json
+import shutil
+import argparse
+import requests
+import config
+import scraperutils
+from scraperutils import bcolors
+
+
+class CustomGPTsScraper:
+    ### Class Variables
+    args = None
+    driver = None
+    ID = "customgptsscraper"
+
+    BACKUP_HREF_FILE_NAME = "../top_gpts_href_values_bak.json"
+    BACKUP_OPENAI_URLS_FILE_NAME = "../top_gpts_openai_urls_bak.json"
+
+    def scrape_all_gpts(self):
+        self.driver.get('https://www.customgpts.info/')
+        # Feedback loop to scroll to the bottom
+        try:
+            LoadMoreButtonExists = True
+            count = 0
+
+            while LoadMoreButtonExists:
+                try:
+                    scraperutils.scroll_to_bottom(self.driver)
+                    time.sleep(2)
+
+                    button = self.driver.find_element(By.XPATH, "//button[contains(text(), 'Load More')]")
+                    self.driver.execute_script("arguments[0].click();", button)
+                    time.sleep(1)
+
+                    count += 1
+                except:
+                    LoadMoreButtonExists = False
+                
+                if count >= 50:
+                    LoadMoreButtonExists = False
+
+        except KeyboardInterrupt:
+            # Handle interruption (e.g., user pressing Ctrl+C)
+            pass
+
+        print("Completed Scrolling to Bottom")
+        elements = self.driver.find_elements(By.TAG_NAME, "a")
+
+        # Create an empty list to store href values
+        href_values = []
+
+        # Iterate through the WebElement array and get href attributes
+        for element in elements:
+            href = element.get_attribute("href")
+            href_values.append(href)
+
+        # Verify the list of href values, remove any None values
+        href_values = [x for x in href_values if x is not None]
+
+        with open(self.BACKUP_HREF_FILE_NAME, "w") as outfile:
+            json.dump(href_values, outfile)
+
+        return href_values
+
+
+    def scrape(self, email_reporting=False) -> list:
+        '''
+        All scrapers must implement this method.
+        It should return a list of OpenAI URLs corresponding to GPTs scraped
+        from the class's web source. scrape() should also accept 3 mandatory kwargs
+        but may also accept additional keyword arguments
+
+        :param email_reporting: Whether it should send an email if there is a failure
+        :return: List of strings that should be valid URLs
+        '''
+        self.driver = scraperutils.start_webdriver()
+        subpage_urls = self.scrape_all_gpts()
+        self.driver.quit()
+
+        openai_urls = []
+        for x in subpage_urls:
+            openai_urls.append(scraperutils.extract_openai_url(x))
+
+        num_failures = openai_urls.count(None)
+        # Count the # of None values in openai_urls
+        print(f"{bcolors.OKCYAN} Failures: {num_failures} {bcolors.ENDC}")
+
+        openai_urls = [x for x in openai_urls if x is not None]
+
+        print("Verifying uniqueness...")
+        dupes = scraperutils.compute_duplicates(openai_urls)
+        if len(dupes) > 0:
+            print(f"{bcolors.WARNING}{len(dupes)} duplicates found{bcolors.ENDC}")
+            print(dupes)
+
+        # Remove duplicates from list
+        openai_urls = list(set(openai_urls))
+
+        with open(self.BACKUP_OPENAI_URLS_FILE_NAME, "w") as outfile:
+            json.dump(openai_urls, outfile)
+
+        return openai_urls
+

--- a/scrapers/gptcollectionscraper.py
+++ b/scrapers/gptcollectionscraper.py
@@ -1,0 +1,103 @@
+import sys
+import time
+
+import selenium
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+# Import chromedriver
+from selenium.webdriver.chrome.options import Options
+import pickle
+
+import traceback
+import os
+import time
+import json
+import shutil
+import argparse
+import requests
+import config
+import scraperutils
+from scraperutils import bcolors
+
+
+class GPTCollectionScraper:
+    ### Class Variables
+    args = None
+    driver = None
+    ID = "gptcollectionscraper"
+
+    BACKUP_HREF_FILE_NAME = "../top_gpts_href_values_bak.json"
+    BACKUP_OPENAI_URLS_FILE_NAME = "../top_gpts_openai_urls_bak.json"
+
+    def scrape_all_gpts(self):
+        self.driver.get('https://gpt-collection.com/')
+        # Feedback loop to scroll to the bottom
+        try:
+            count = 0
+            while count <= 50:
+                scraperutils.scroll_to_bottom(self.driver)
+                time.sleep(2)
+
+                count += 1
+        except KeyboardInterrupt:
+            # Handle interruption (e.g., user pressing Ctrl+C)
+            pass
+
+        print("Completed Scrolling to Bottom")
+        elements = self.driver.find_elements(By.TAG_NAME, "a")
+
+        # Create an empty list to store href values
+        href_values = []
+
+        # Iterate through the WebElement array and get href attributes
+        for element in elements:
+            href = element.get_attribute("href")
+            href_values.append(href)
+
+        # Verify the list of href values, remove any None values
+        href_values = [x for x in href_values if x is not None]
+
+        with open(self.BACKUP_HREF_FILE_NAME, "w") as outfile:
+            json.dump(href_values, outfile)
+
+        return href_values
+
+
+    def scrape(self, email_reporting=False) -> list:
+        '''
+        All scrapers must implement this method.
+        It should return a list of OpenAI URLs corresponding to GPTs scraped
+        from the class's web source. scrape() should also accept 3 mandatory kwargs
+        but may also accept additional keyword arguments
+
+        :param email_reporting: Whether it should send an email if there is a failure
+        :return: List of strings that should be valid URLs
+        '''
+        self.driver = scraperutils.start_webdriver()
+        subpage_urls = self.scrape_all_gpts()
+        self.driver.quit()
+
+        openai_urls = []
+        for x in subpage_urls:
+            openai_urls.append(scraperutils.extract_openai_url(x))
+
+        num_failures = openai_urls.count(None)
+        # Count the # of None values in openai_urls
+        print(f"{bcolors.OKCYAN} Failures: {num_failures} {bcolors.ENDC}")
+
+        openai_urls = [x for x in openai_urls if x is not None]
+
+        print("Verifying uniqueness...")
+        dupes = scraperutils.compute_duplicates(openai_urls)
+        if len(dupes) > 0:
+            print(f"{bcolors.WARNING}{len(dupes)} duplicates found{bcolors.ENDC}")
+            print(dupes)
+
+        # Remove duplicates from list
+        openai_urls = list(set(openai_urls))
+
+        with open(self.BACKUP_OPENAI_URLS_FILE_NAME, "w") as outfile:
+            json.dump(openai_urls, outfile)
+
+        return openai_urls
+

--- a/scrapers/gptdirectoryscraper.py
+++ b/scrapers/gptdirectoryscraper.py
@@ -1,0 +1,82 @@
+
+import sys
+import time
+from selenium.webdriver.common.by import By
+
+import traceback
+
+import os
+import sys
+import time
+import json
+import shutil
+import argparse
+import requests
+import sys
+import config
+import scraperutils
+from scraperutils import send_email
+from scraperutils import bcolors
+
+
+class GPTDirectoryScraper:
+    ### Global Variables
+    args = None
+    driver = None
+    ID = "gptdirectoryscraper"
+
+    BACKUP_HREF_FILE_NAME = "../{}_href_values_bak.json".format(ID)
+    BACKUP_OPENAI_URLS_FILE_NAME = "../{}_openai_urls_bak.json".format(ID)
+
+    def scrape_all_gpts(self):
+        '''
+        Gets a list of subpages from plugin.surf that may contain openAI urls
+        :return:
+        '''
+        self.driver.get('https://www.gptdirectory.co/')
+
+        try:
+            SeeMoreButtonExists = True
+            # count = 0
+
+            while SeeMoreButtonExists:
+                try:
+                    scraperutils.scroll_to_bottom(self.driver)
+                    time.sleep(2)
+
+                    button = self.driver.find_element(By.XPATH, "//button[contains(text(), 'See more')]")
+                    self.driver.execute_script("arguments[0].click();", button)
+                    time.sleep(1)
+
+                    # count += 1
+                except:
+                    SeeMoreButtonExists = False
+                
+                # if count >= 3:
+                #     SeeMoreButtonExists = False
+
+        except KeyboardInterrupt:
+            # Handle interruption (e.g., user pressing Ctrl+C)
+            pass
+
+        time.sleep(1)
+        dumped_html_string = self.driver.page_source
+        return dumped_html_string
+
+    def scrape(self, email_reporting=False) -> list:
+        '''
+        All scrapers must implement this method.
+        It should return a list of OpenAI URLs corresponding to GPTs scraped
+        from the class's web source. scrape() should also accept 3 mandatory kwargs
+        but may also accept additional keyword arguments
+
+        :param email_reporting: Whether it should send an email if there is a failure
+        :return: List of strings that should be valid URLs
+        '''
+        self.driver = scraperutils.start_webdriver()
+        main_page_dump = self.scrape_all_gpts()
+        self.driver.quit()
+
+        openai_urls = scraperutils.bulk_extract_openai_url(main_page_dump)
+
+        return openai_urls


### PR DESCRIPTION
Four new scrapers:
- customgptslistscraper: scroll down, go to the subpages, and scrape the URLs
- gptdirectoryscraper:
    - scroll down and click the “See more” button until we can’t see the “See more” button (it has 399 URLs in total so it takes some time like 5-10 minutes to reach the bottom)
    - Just in case, I created and commented the variable called “count”, which set the maximum number of clicking the “See more” button.
- customgptsscraper: scroll down, click the “load more” button until the variable “count” reaches 50 (I tried to run until we couldn’t see the “Load More” button but it didn’t reach the bottom although I ran it more than 30 minutes), and go to subpages.
- gptcollectionscraper: scroll down until until the variable “count” reaches 50 (I tried to run until we couldn’t see the “Load More” button but it didn’t reach the bottom although I ran it more than 15 minutes) and go to subpages.

**Note: All four scraper works. However, customgptslistscraper, customgptsscraper, and gptcollectionscraper give some “Failure to locate url” messages first before scraping URLs. I think this is because they tried accessing tags in the category section.**